### PR TITLE
Provide seq multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,11 +238,11 @@ You can also keep parts of the sequence of the diffused chain fixed, if you want
 ```
 'contigmap.contigs=[100-100/0 20-20]' 'contigmap.provide_seq=[100-119]' diffuser.partial_T=10
 ```
-In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide). Multiple sequence ranges can be provided separated by a comma, e.g. `'contigmap.provide_seq=[172-177,200-205]'`. An example can be found in `./examples/design_partialdiffusion_multipleseq.sh`.
+In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide). Multiple sequence ranges can be provided separated by a comma, e.g. `'contigmap.provide_seq=[172-177,200-205]'`.
 
 Note that the provide_seq option requires using a different model checkpoint, but this is automatically handled by the inference script.
 
-An example of partial diffusion with providing sequence in diffused regions can be found in `./examples/design_partialdiffusion_withseq.sh`.
+An example of partial diffusion with providing sequence in diffused regions can be found in `./examples/design_partialdiffusion_withseq.sh`. The same example specifying multiple sequence ranges can be found in `./examples/design_partialdiffusion_multipleseq.sh`.
 
 ---
 ### Binder Design 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ You can also keep parts of the sequence of the diffused chain fixed, if you want
 ```
 'contigmap.contigs=[100-100/0 20-20]' 'contigmap.provide_seq=[100-119]' diffuser.partial_T=10
 ```
-In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide).
+In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide). Multiple sequence ranges can be provided separated by a comma, e.g. `'contigmap.provide_seq=[0-10,20-30]'`.
 
 Note that the provide_seq option requires using a different model checkpoint, but this is automatically handled by the inference script.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ You can also keep parts of the sequence of the diffused chain fixed, if you want
 ```
 'contigmap.contigs=[100-100/0 20-20]' 'contigmap.provide_seq=[100-119]' diffuser.partial_T=10
 ```
-In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide). Multiple sequence ranges can be provided separated by a comma, e.g. `'contigmap.provide_seq=[0-10,20-30]'`.
+In this case, the 20aa chain is the helical peptide. The `contigmap.provide_seq` input is zero-indexed, and you can provide a range (so 100-119 is an inclusive range, unmasking the whole sequence of the peptide). Multiple sequence ranges can be provided separated by a comma, e.g. `'contigmap.provide_seq=[172-177,200-205]'`. An example can be found in `./examples/design_partialdiffusion_multipleseq.sh`.
 
 Note that the provide_seq option requires using a different model checkpoint, but this is automatically handled by the inference script.
 

--- a/examples/design_partialdiffusion_multipleseq.sh
+++ b/examples/design_partialdiffusion_multipleseq.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This example is a copy of design_partialdiffusion_withseq.sh
+# The only difference is we specify multiple disjoint sequences to hold constant.
+# In this case, we provide the residues of the beginning and end of the peptide, instead of the whole sequence.
+# We can provide comma-separated ranges to specify this: provide_seq=[172-177,200-205]
+# Note the ranges do not necessarily need to lie on the same chain as in this example.
+# However, positions are 0-indexed over the whole sequence--not per-chain-- so care must be taken when providing ranges to provide_seq.
+
+../scripts/run_inference.py inference.output_prefix=example_outputs/design_partialdiffusion_peptidewithsequence inference.input_pdb=input_pdbs/peptide_complex_ideal_helix.pdb 'contigmap.contigs=["172-172/0 34-34"]' diffuser.partial_T=10 inference.num_designs=10 'contigmap.provide_seq=[172-177,200-205]'

--- a/examples/design_partialdiffusion_multipleseq.sh
+++ b/examples/design_partialdiffusion_multipleseq.sh
@@ -6,4 +6,4 @@
 # Note the ranges do not necessarily need to lie on the same chain as in this example.
 # However, positions are 0-indexed over the whole sequence--not per-chain-- so care must be taken when providing ranges to provide_seq.
 
-../scripts/run_inference.py inference.output_prefix=example_outputs/design_partialdiffusion_peptidewithsequence inference.input_pdb=input_pdbs/peptide_complex_ideal_helix.pdb 'contigmap.contigs=["172-172/0 34-34"]' diffuser.partial_T=10 inference.num_designs=10 'contigmap.provide_seq=[172-177,200-205]'
+../scripts/run_inference.py inference.output_prefix=example_outputs/design_partialdiffusion_peptidewithmultiplesequence inference.input_pdb=input_pdbs/peptide_complex_ideal_helix.pdb 'contigmap.contigs=["172-172/0 34-34"]' diffuser.partial_T=10 inference.num_designs=10 'contigmap.provide_seq=[172-177,200-205]'

--- a/rfdiffusion/contigs.py
+++ b/rfdiffusion/contigs.py
@@ -118,7 +118,7 @@ class ContigMap:
 
         # Handle provide seq. This is zero-indexed, and used only for partial diffusion
         if provide_seq is not None:
-            for i in provide_seq[0].split(","):
+            for i in provide_seq:
                 if "-" in i:
                     self.inpaint_seq[
                         int(i.split("-")[0]) : int(i.split("-")[1]) + 1


### PR DESCRIPTION
The user should be allowed to specify multiple regions with the `provide_seq` when doing partial diffusion, but a bug in the processing the contig prevents this from working properly. This PR fixes it.  Issue #31 

If you are interested, I can add an example. Thanks!