### PR TITLE
Swapped arguments when creating SymGen

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -136,9 +136,9 @@ class Sampler:
         if self.inf_conf.symmetry is not None:
             self.symmetry = symmetry.SymGen(
                 self.inf_conf.symmetry,
-                self.inf_conf.model_only_neighbors,
                 self.inf_conf.recenter,
-                self.inf_conf.radius, 
+                self.inf_conf.radius,
+                self.inf_conf.model_only_neighbors,
             )
         else:
             self.symmetry = None

--- a/rfdiffusion/inference/symmetry.py
+++ b/rfdiffusion/inference/symmetry.py
@@ -33,7 +33,7 @@ saved_symmetries = ['tetrahedral', 'octahedral', 'icosahedral']
 
 class SymGen:
 
-    def __init__(self, global_sym, recenter, radius, model_only_neibhbors=False):
+    def __init__(self, global_sym, recenter, radius, model_only_neighbors=False):
         self._log = logging.getLogger(__name__)
         self._recenter = recenter
         self._radius = radius


### PR DESCRIPTION
Hello!

I noticed that when the `Sampler` creates the `SymGen` object, its arguments are swapped as compared to the `__init__` method. That is,
In `Sampler`:
```            
self.symmetry = symmetry.SymGen(
                self.inf_conf.symmetry,
                self.inf_conf.model_only_neighbors,
                self.inf_conf.recenter,
                self.inf_conf.radius, 
            )
```
But the `__init__` of `SymGen` is:
```
def __init__(self, global_sym, recenter, radius, model_only_neibhbors=False):
```

I corrected this by swapping the arguments when creating `self.symmetry`. I also fixed the typo `model_only_neibhbors` -> `model_only_neighbors`.

Please let me know if I can do anything!