### PR TITLE
Fix symmetric oligomer example bug in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ We're going to switch gears from discussing PPI and look at another task at whic
 
 Here's an example:
 ```
-./scripts/run_inference.py --config-name symmetry  inference.symmetry=tetrahedral 'contigmap.contigs=[360]' inference.output_prefix=test_sample/tetrahedral inference.num_designs=1
+./scripts/run_inference.py --config-name symmetry  inference.symmetry=tetrahedral 'contigmap.contigs=[360-360]' inference.output_prefix=test_sample/tetrahedral inference.num_designs=1
 ```
 
 Here, we've specified a different `config` file (with `--config-name symmetry`). Because symmetric diffusion is quite different from the diffusion described above, we packaged a whole load of symmetry-related configs into a new file (see `configs/inference/symmetry.yml`). Using this config file now puts diffusion in `symmetry-mode`.


### PR DESCRIPTION
`contigmap.contigs` expects a range.