### PR TITLE
Fixed Dockerfile numpy version bug

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -q update \
   decorator==5.1.0 \
   hydra-core==1.3.2 \
   pyrsistent==0.19.3 \
+  numpy==1.26.4 \
   /app/RFdiffusion/env/SE3Transformer \
   && pip install --no-cache-dir /app/RFdiffusion --no-deps
   


### PR DESCRIPTION
# Problem
Numpy version 2.0.0 (released Jun 16, 2024) breaks Docker image

### Test Run
```bash
docker build -f docker/Dockerfile -t rfdiffusion .
```
```bash
docker run -it --rm --gpus all \
  -v $HOME/models:$HOME/models \
  -v $HOME/inputs:$HOME/inputs \
  -v $HOME/outputs:$HOME/outputs \
  rfdiffusion \
  inference.output_prefix=$HOME/outputs/motifscaffolding \
  inference.model_directory_path=$HOME/models \
  inference.input_pdb=$HOME/inputs/5TPN.pdb \
  inference.num_designs=3 \
  'contigmap.contigs=[10-40/A163-181/10-40]'
```

### Test Output
```bash
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "/app/RFdiffusion/scripts/run_inference.py", line 24, in <module>
    from rfdiffusion.util import writepdb_multi, writepdb
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/util.py", line 2, in <module>
    from rfdiffusion.chemical import *
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/chemical.py", line 184, in <module>
    init_N = torch.tensor([-0.5272, 1.3593, 0.000]).float()
/usr/local/lib/python3.9/dist-packages/rfdiffusion/chemical.py:184: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at  ../torch/csrc/utils/tensor_numpy.cpp:68.)
  init_N = torch.tensor([-0.5272, 1.3593, 0.000]).float()
[2024-06-18 21:35:00,380][__main__][INFO] - Found GPU with device_name NVIDIA GeForce GTX 1080 Ti. Will run RFdiffusion on NVIDIA GeForce GTX 1080 Ti
Reading models from /home/alextaguchi/models
[2024-06-18 21:35:00,381][rfdiffusion.inference.model_runners][INFO] - Reading checkpoint from /home/alextaguchi/models/Base_ckpt.pt
This is inf_conf.ckpt_path
/home/alextaguchi/models/Base_ckpt.pt
Assembling -model, -diffuser and -preprocess configs from checkpoint
USING MODEL CONFIG: self._conf[model][n_extra_block] = 4
USING MODEL CONFIG: self._conf[model][n_main_block] = 32
USING MODEL CONFIG: self._conf[model][n_ref_block] = 4
USING MODEL CONFIG: self._conf[model][d_msa] = 256
USING MODEL CONFIG: self._conf[model][d_msa_full] = 64
USING MODEL CONFIG: self._conf[model][d_pair] = 128
USING MODEL CONFIG: self._conf[model][d_templ] = 64
USING MODEL CONFIG: self._conf[model][n_head_msa] = 8
USING MODEL CONFIG: self._conf[model][n_head_pair] = 4
USING MODEL CONFIG: self._conf[model][n_head_templ] = 4
USING MODEL CONFIG: self._conf[model][d_hidden] = 32
USING MODEL CONFIG: self._conf[model][d_hidden_templ] = 32
USING MODEL CONFIG: self._conf[model][p_drop] = 0.15
USING MODEL CONFIG: self._conf[model][SE3_param_full] = {'num_layers': 1, 'num_channels': 32, 'num_degrees': 2, 'n_heads': 4, 'div': 4, 'l0_in_features': 8, 'l0_out_features': 8, 'l1_in_features': 3, 'l1_out_features': 2, 'num_edge_features': 32}
USING MODEL CONFIG: self._conf[model][SE3_param_topk] = {'num_layers': 1, 'num_channels': 32, 'num_degrees': 2, 'n_heads': 4, 'div': 4, 'l0_in_features': 64, 'l0_out_features': 64, 'l1_in_features': 3, 'l1_out_features': 2, 'num_edge_features': 64}
USING MODEL CONFIG: self._conf[model][freeze_track_motif] = False
USING MODEL CONFIG: self._conf[model][use_motif_timestep] = True
USING MODEL CONFIG: self._conf[diffuser][T] = 50
USING MODEL CONFIG: self._conf[diffuser][b_0] = 0.01
USING MODEL CONFIG: self._conf[diffuser][b_T] = 0.07
USING MODEL CONFIG: self._conf[diffuser][schedule_type] = linear
USING MODEL CONFIG: self._conf[diffuser][so3_type] = igso3
USING MODEL CONFIG: self._conf[diffuser][crd_scale] = 0.25
USING MODEL CONFIG: self._conf[diffuser][so3_schedule_type] = linear
USING MODEL CONFIG: self._conf[diffuser][min_b] = 1.5
USING MODEL CONFIG: self._conf[diffuser][max_b] = 2.5
USING MODEL CONFIG: self._conf[diffuser][min_sigma] = 0.02
USING MODEL CONFIG: self._conf[diffuser][max_sigma] = 1.5
USING MODEL CONFIG: self._conf[preprocess][sidechain_input] = False
USING MODEL CONFIG: self._conf[preprocess][motif_sidechain_input] = True
USING MODEL CONFIG: self._conf[preprocess][d_t1d] = 22
USING MODEL CONFIG: self._conf[preprocess][d_t2d] = 44
USING MODEL CONFIG: self._conf[preprocess][prob_self_cond] = 0.5
USING MODEL CONFIG: self._conf[preprocess][str_self_cond] = True
USING MODEL CONFIG: self._conf[preprocess][predict_previous] = False
[2024-06-18 21:35:06,851][rfdiffusion.inference.model_runners][INFO] - Loading checkpoint.
[2024-06-18 21:35:12,279][rfdiffusion.diffusion][INFO] - Calculating IGSO3.
Error executing job with overrides: ['inference.output_prefix=/home/alextaguchi/outputs/motifscaffolding', 'inference.model_directory_path=/home/alextaguchi/models', 'inference.input_pdb=/home/alextaguchi/inputs/5TPN.pdb', 'inference.num_designs=3', 'contigmap.contigs=[10-40/A163-181/10-40]']
Traceback (most recent call last):
  File "/app/RFdiffusion/scripts/run_inference.py", line 54, in main
    sampler = iu.sampler_selector(conf)
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/inference/utils.py", line 511, in sampler_selector
    sampler = model_runners.SelfConditioning(conf)
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/inference/model_runners.py", line 37, in __init__
    self.initialize(conf)
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/inference/model_runners.py", line 130, in initialize
    self.diffuser = Diffuser(**self._conf.diffuser, cache_dir=schedule_directory)
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/diffusion.py", line 582, in __init__
    self.so3_diffuser = IGSO3(
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/diffusion.py", line 198, in __init__
    self.igso3_vals = self._calc_igso3_vals(L=L)
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/diffusion.py", line 236, in _calc_igso3_vals
    igso3_vals = igso3.calculate_igso3(
  File "/usr/local/lib/python3.9/dist-packages/rfdiffusion/igso3.py", line 93, in calculate_igso3
    discrete_sigma = 10 ** np.linspace(np.log10(min_sigma), np.log10(max_sigma), num_sigma + 1)[1:]
  File "/usr/local/lib/python3.9/dist-packages/torch/_tensor.py", line 757, in __array__
    return self.numpy()
RuntimeError: Numpy is not available

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```

# Solution
Use newest version of numpy (1.26.4) below 2.0.0