### PR TITLE
use user HOME dir for cache, config, models

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -18,7 +18,8 @@ import os
 from rfdiffusion.model_input_logger import pickle_function_call
 import sys
 
-SCRIPT_DIR=os.path.dirname(os.path.realpath(__file__))
+from rfdiffusion.util import USER_DIR
+
 
 TOR_INDICES  = util.torsion_indices
 TOR_CAN_FLIP = util.torsion_can_flip
@@ -63,7 +64,8 @@ class Sampler:
         if conf.inference.model_directory_path is not None:
             model_directory = conf.inference.model_directory_path
         else:
-            model_directory = f"{SCRIPT_DIR}/../../models"
+            # set default model weigths directory under env var control. fallback to user $HOME/rfdiffusion/models
+            model_directory = os.environ.get('RFD_MODELS',f"{USER_DIR}/models")
 
         print(f"Reading models from {model_directory}")
 
@@ -122,7 +124,7 @@ class Sampler:
         if conf.inference.schedule_directory_path is not None:
             schedule_directory = conf.inference.schedule_directory_path
         else:
-            schedule_directory = f"{SCRIPT_DIR}/../../schedules"
+            schedule_directory = f"{USER_DIR}/schedules"
 
         # Check for cache schedule
         if not os.path.exists(schedule_directory):

--- a/rfdiffusion/util.py
+++ b/rfdiffusion/util.py
@@ -2,6 +2,17 @@ import scipy.sparse
 from rfdiffusion.chemical import *
 from rfdiffusion.scoring import *
 
+import sys
+from pathlib import Path
+# define RFdiffusion directory located in user HOME directory.
+USER_HOME=str(Path.home())
+USER_DIR=f"{USER_HOME}/rfdiffusion"
+
+try:
+    Path(USER_DIR).mkdir(parents=True, exist_ok=True)
+except FileExistsError as msg:
+    print(f'{USER_DIR} already exist and is a file.')
+    sys.exit(1)
 
 def generate_Cbeta(N, Ca, C):
     # recreate Cb given N,Ca,C

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -21,12 +21,15 @@ import torch
 from omegaconf import OmegaConf
 import hydra
 import logging
-from rfdiffusion.util import writepdb_multi, writepdb
+from rfdiffusion.util import writepdb_multi, writepdb, USER_DIR
 from rfdiffusion.inference import utils as iu
 from hydra.core.hydra_config import HydraConfig
 import numpy as np
 import random
 import glob
+
+# set hyfra inference config dir under environment variable control
+hydra_cfg_dir=os.environ.get('RFD_HYDRA_CFG', f"{USER_DIR}/config/inference")
 
 
 def make_deterministic(seed=0):
@@ -35,7 +38,7 @@ def make_deterministic(seed=0):
     random.seed(seed)
 
 
-@hydra.main(version_base=None, config_path="../config/inference", config_name="base")
+@hydra.main(version_base=None, config_path=hydra_cfg_dir, config_name="base")
 def main(conf: HydraConfig) -> None:
     log = logging.getLogger(__name__)
     if conf.inference.deterministic:


### PR DESCRIPTION
related to https://github.com/RosettaCommons/RFdiffusion/issues/252

PR propose to have a `$HOME/rfdiffusion` that will hold all necessary files where write erpmission is required.
with this PR:
- inference config files location  are seaerchd from `$HOME/rfdiffusion/config/inference/`
- IGSO3 are cahed to `$HOME/rfdiffusion/schedules`
- weight models are exepected in `$HOME/rfdiffusion/models`

furthermore the PR allows weight models directory search to be overwritten by `RFD_MODELS` environment variable.
by default check in `$HOME/rfdiffusion/models` and search `$RFD_MODELS` instead if is defined 
(allow mutualisation of models on a shared cluster)
same for inference config files, if `RFD_HYDRA_CFG` is defined.

regards

Eric