### PR TITLE
Enable running with T < 15

### DIFF
--- a/env/SE3Transformer/se3_transformer/model/basis.py
+++ b/env/SE3Transformer/se3_transformer/model/basis.py
@@ -29,7 +29,7 @@ import e3nn.o3 as o3
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.monitoring import nvtx_range
 
 from se3_transformer.runtime.utils import degree_to_dim
 

--- a/env/SE3Transformer/se3_transformer/model/layers/attention.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/attention.py
@@ -34,7 +34,7 @@ from se3_transformer.model.fiber import Fiber
 from se3_transformer.model.layers.convolution import ConvSE3, ConvSE3FuseLevel
 from se3_transformer.model.layers.linear import LinearSE3
 from se3_transformer.runtime.utils import degree_to_dim, aggregate_residual, unfuse_features
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.monitoring import nvtx_range
 
 
 class AttentionSE3(nn.Module):

--- a/env/SE3Transformer/se3_transformer/model/layers/convolution.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/convolution.py
@@ -31,7 +31,7 @@ import torch
 import torch.nn as nn
 from dgl import DGLGraph
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.monitoring import nvtx_range
 
 from se3_transformer.model.fiber import Fiber
 from se3_transformer.runtime.utils import degree_to_dim, unfuse_features

--- a/env/SE3Transformer/se3_transformer/model/layers/norm.py
+++ b/env/SE3Transformer/se3_transformer/model/layers/norm.py
@@ -27,7 +27,7 @@ from typing import Dict
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+from se3_transformer.model.monitoring import nvtx_range
 
 from se3_transformer.model.fiber import Fiber
 

--- a/env/SE3Transformer/se3_transformer/model/monitoring.py
+++ b/env/SE3Transformer/se3_transformer/model/monitoring.py
@@ -1,0 +1,15 @@
+import warnings
+
+try:
+    from torch._C import _nvtx
+    from torch.cuda.nvtx import range as nvtx_range
+except ImportError as e:
+    warnings.warn(f'NVTX is not available: {e}')
+
+    class MockNvtx:
+        def __enter__(self):
+            pass
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    nvtx_range = lambda t: MockNvtx()

--- a/rfdiffusion/diffusion.py
+++ b/rfdiffusion/diffusion.py
@@ -25,7 +25,11 @@ def get_beta_schedule(T, b0, bT, schedule_type, schedule_params={}, inference=Fa
 
     # Adjust b0 and bT if T is not 200
     # This is a good approximation, with the beta correction below, unless T is very small
-    assert T >= 15, "With discrete time and T < 15, the schedule is badly approximated"
+    assert T >= 1, 'T must be at least 1'
+    if T < 15:
+        print('!!!')
+        print("!!! With discrete time and T < 15, the schedule is badly approximated !!!")
+        print('!!!')
     b0 *= 200 / T
     bT *= 200 / T
 


### PR DESCRIPTION
Running with T=1 provides a quick preview, mainly in scaffold design scenario. We have an internal fork with this functionality but we prefer to stay synchronized with the public version.

A warning will be shown instead.