### PR TITLE
Retain chain and residue numbering in RFdiffusion

### DIFF
--- a/rfdiffusion/inference/model_runners.py
+++ b/rfdiffusion/inference/model_runners.py
@@ -309,8 +309,16 @@ class Sampler:
         contig_map=self.contig_map
 
         self.diffusion_mask = self.mask_str
-        self.chain_idx=['A' if i < self.binderlen else 'B' for i in range(L_mapped)]
-        
+        length_bound = self.contig_map.sampled_mask_length_bound.copy()
+
+        first_res = 0
+        self.chain_idx = []
+        for last_res in length_bound:
+            chain_ids = {contig_ref[0] for contig_ref in self.contig_map.ref[first_res: last_res]} - {"_"}
+            assert len(chain_ids) == 1, f"Error: Multiple chain IDs in chain: {chain_ids}"
+            self.chain_idx += [list(chain_ids)[0]] * (last_res - first_res)
+            first_res = last_res
+
         ####################################
         ### Generate initial coordinates ###
         ####################################

--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -141,6 +141,7 @@ def main(conf: HydraConfig) -> None:
             sampler.binderlen,
             chain_idx=sampler.chain_idx,
             bfacts=bfacts,
+            idx_pdb=sampler.idx_pdb
         )
 
         # run metadata


### PR DESCRIPTION
A number of issues (e.g., #103 , #171  , https://github.com/RosettaCommons/RFdiffusion/issues/312 , #315 ) have mentioned that RFdiffusion will change the chain IDs and residue numbering of the input structure. The designed chain ends up as chain "A", and the fixed chain(s) end up as chain "B". The numbering is also reset to start at 1. This can be particularly problematic in cases where comparisons to structures are needed, as well as multi-chain situations where all of the chains get fused.

Inspired by @GCS-ZHN 's comment and solution referenced in Issue #103 , I've modified the code to maintain chain and residue numbering. In particular:

Chains that are not "designable" will retain their original chain ID letters and residue numbers.
Chains that are partially fixed (e.g., motif re-scaffolding) will retain their original chain ID letters. Residues will be re-numbered from 1 to length of chain. (It was not clear to me what the "correct" behaviour of chain residue numbering should be, given that the length of the chain and the position of any fixed residues might change.)
Chains that are being fully generated de novo will be assigned the first available chain ID in the alphabet not used by any other chain. Residues will be numbered from 1 to length of chain.