### PR TITLE
add GitHub CI workflow for running ppi-scaffolds tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,95 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python application
+
+on:
+  push:
+    branches: [ "main", "github-ci" ]
+  pull_request:
+    branches: [ "main", "github-ci" ]
+
+permissions:
+  contents: read
+
+jobs:
+  ppi-scaffolds-test:
+
+    #runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    #container: nvcr.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu20.04
+    container: nvcr.io/nvidia/cuda:11.6.2-cudnn8-runtime-ubuntu20.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     #pip install flake8 pytest
+    #     pip install pytest
+    #     if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # - name: Lint with flake8
+    #   run: |
+    #     # stop the build if there are Python syntax errors or undefined names
+    #     flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+    #     # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+    #     flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+    - name: Install dependencies
+      run: |
+        apt-get update -qq && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        curl \
+        wget \
+        ca-certificates
+
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        . $HOME/.local/bin/env bash
+
+        uv python install 3.9
+        uv venv
+        uv pip install --no-cache-dir -q \
+          dgl==1.0.2+cu116 -f https://data.dgl.ai/wheels/cu116/repo.html \
+          torch==1.12.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 \
+          e3nn==0.3.3 \
+          wandb==0.12.0 \
+          pynvml==11.0.0 \
+          git+https://github.com/NVIDIA/dllogger#egg=dllogger \
+          decorator==5.1.0 \
+          hydra-core==1.3.2 \
+          pyrsistent==0.19.3 \
+          pytest
+
+        uv pip install --no-cache-dir env/SE3Transformer
+        uv pip install --no-cache-dir -e . --no-deps
+        rm -rf ~/.cache # /app/RFdiffusion/tests
+
+    - name: Download weights
+      run: |
+        mkdir models
+        wget -q -O models/Base_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/6f5902ac237024bdd0c176cb93063dc4/Base_ckpt.pt
+        wget -q -O models/Complex_base_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/e29311f6f1bf1af907f9ef9f44b8328b/Complex_base_ckpt.pt
+        wget -q -O models/Complex_Fold_base_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/60f09a193fb5e5ccdc4980417708dbab/Complex_Fold_base_ckpt.pt
+        wget -q -O models/InpaintSeq_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/74f51cfb8b440f50d70878e05361d8f0/InpaintSeq_ckpt.pt
+        wget -q -O models/InpaintSeq_Fold_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/76d00716416567174cdb7ca96e208296/InpaintSeq_Fold_ckpt.pt
+        wget -q -O models/ActiveSite_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/5532d2e1f3a4738decd58b19d633b3c3/ActiveSite_ckpt.pt
+        wget -q -O models/Base_epoch8_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/12fc204edeae5b57713c5ad7dcb97d39/Base_epoch8_ckpt.pt
+        #optional
+        wget -q -O models/Complex_beta_ckpt.pt http://files.ipd.uw.edu/pub/RFdiffusion/f572d396fae9206628714fb2ce00f72e/Complex_beta_ckpt.pt
+        #original structure prediction weights
+        wget -q -O models/RF_structure_prediction_weights.pt http://files.ipd.uw.edu/pub/RFdiffusion/1befcb9b28e2f778f53d47f18b7597fa/RF_structure_prediction_weights.pt
+
+    - name: Setup and Run ppi_scaffolds tests
+      run: |
+        tar -xvf examples/ppi_scaffolds_subset.tar.gz -C examples
+        cd tests && uv run python test_diffusion.py
+
+
+    # - name: Test with pytest
+    #   run: |
+    #     pytest


### PR DESCRIPTION
Logs from example runs could be found at https://github.com/lyskov/RFdiffusion/actions/runs/15809450106/job/44558777140