### PR TITLE
Fix: Conditionally pass idx_pdb to writepdb to avoid AttributeError with SelfConditioning/ScaffoldedSampler

### DIFF
--- a/scripts/run_inference.py
+++ b/scripts/run_inference.py
@@ -141,7 +141,7 @@ def main(conf: HydraConfig) -> None:
             sampler.binderlen,
             chain_idx=sampler.chain_idx,
             bfacts=bfacts,
-            idx_pdb=sampler.idx_pdb
+            **({"idx_pdb": sampler.idx_pdb} if hasattr(sampler, "idx_pdb") else {})
         )
 
         # run metadata


### PR DESCRIPTION
This PR resolves an AttributeError that occurs when running the example script design_macrocyclic_binder.sh using the SelfConditioning or ScaffoldedSampler samplers.
After PR #348, the code attempted to pass sampler.idx_pdb to the writepdb function, but certain sampler classes (such as SelfConditioning and ScaffoldedSampler) do not always define the idx_pdb attribute. This resulted in a runtime error.

With this change, idx_pdb is only passed to writepdb if the sampler object actually has the attribute. 