### PR TITLE
Fix github workflow tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
         uv python install 3.9
         uv venv
         uv pip install --no-cache-dir -q \
+          'numpy<2' \
           dgl==1.0.2+cu116 -f https://data.dgl.ai/wheels/cu116/repo.html \
           torch==1.12.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116 \
           e3nn==0.3.3 \


### PR DESCRIPTION
torch==1.12.1 is built against NumPy 1.x, but the CI install pinned no NumPy version and resolved to NumPy 2.x, causing every torch tensor .numpy() call to fail with 'Numpy is not available' during Diffuser initialization. Constrain the resolution back to NumPy 1.x.